### PR TITLE
Tweaked Shadow Realm location matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Welcome to Ezhobo, your one stop shop for all things Hobopolis automation scripting and the basis of the Ascension Speed Society's Feeding (on) the Homeless Initiative.
 
 ## Installation:
-`git checkout https://github.com/Thingamore/EZHobo.git`
+`git checkout https://github.com/Infopowerbroker/EZHobo.git`
 
 
 ## Requirements:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # EZHobo
 Welcome to Ezhobo, your one stop shop for all things Hobopolis automation scripting and the basis of the Ascension Speed Society's Feeding (on) the Homeless Initiative.
 
+## Note:
+This is a fork of Thingamore's script, attempting to fix a weird behavior in Shadow Rift CCS. 
+
 ## Installation:
 `git checkout https://github.com/Infopowerbroker/EZHobo.git`
 

--- a/scripts/ezhobo.ash
+++ b/scripts/ezhobo.ash
@@ -28,6 +28,8 @@ newline();
 print_html("<p><center>INT <font color=66b2b2>ezhobo_square </font> - Only farms the square, stopping at the desired square image.</center></p>");
 newline();
 print_html("<p><center>BOOLEAN <font color=66b2b2>ezhobo_solo</font> - Are you running this script by yourself? Defaults to false. </center></p>");
+newline();
+print_html("<p><center>BOOLEAN <font color=66b2b2>ezhobo_noAutumnaton</font> - Refrains from using your Autumn-aton.</center></p>");
 print_html("<center> To adjust or set these options, type `set {option} = {input}` in the GCLI. </center>");
 abort("");
 }
@@ -38,9 +40,8 @@ if (my_adventures() == 0 || turns <= 0){
   abort("No more alloted turns to spend!");
 }
 
-/* the following blocks are unrelated to hobopolis and are causing issues for some players (specifically the shadow rift visits) so i am commenting them out -Kuile
-
-if(item_amount($item[Autumn-aton]).to_boolean()){
+// a player specifically requested keeping this feature, so i am leaving it but adding an option to disable it -Kuile
+if(item_amount($item[Autumn-aton]).to_boolean() && !get_property("ezhobo_noAutumnaton").to_boolean()){
   print("Sending your autumn-aton!", "green");
 
   string autumnaton_location;
@@ -51,6 +52,8 @@ if(item_amount($item[Autumn-aton]).to_boolean()){
   }
   cli_execute(`autumnaton send {autumnaton_location}`);
 }
+
+/* the following blocks are unrelated to hobopolis and are causing issues for some players (specifically the shadow rift visits) so i am commenting them out -Kuile
 
 if((have_effect($effect[Everything Looks Yellow]) == 0) && (available_amount($item[Jurassic Parka]).to_boolean() && (can_adventure($location[Shadow Rift]) || can_adventure($location[Thugnderdome])))){
   print("Using your free YR!", "green");  

--- a/scripts/ezhobo.ash
+++ b/scripts/ezhobo.ash
@@ -38,6 +38,8 @@ if (my_adventures() == 0 || turns <= 0){
   abort("No more alloted turns to spend!");
 }
 
+/* the following blocks are unrelated to hobopolis and are causing issues for some players (specifically the shadow rift visits) so i am commenting them out -Kuile
+
 if(item_amount($item[Autumn-aton]).to_boolean()){
   print("Sending your autumn-aton!", "green");
 
@@ -79,6 +81,8 @@ if(((get_property("_coldMedicineConsults")) <= 5) && visit_url("campground.php?a
   visit_url("campground.php?action=workshed");
   run_choice(5);
 } 
+
+*/
 
 if(item_amount($item[Hobo Nickel]) > 0 && !get_property("ezhobo_doNotCloset").to_boolean()){
   put_closet(item_amount($item[Hobo nickel]), $item[Hobo Nickel]);

--- a/scripts/ezhobo_combat.ash
+++ b/scripts/ezhobo_combat.ash
@@ -28,7 +28,7 @@ string hobo_combat(int round, monster mon_encountered, string pagetext) {
 
 
  // Check for non-hobo zones. (e.g YRs from parka)
- if(my_location() == $location[Shadow Rift] || my_location() == $location[Thugnderdome]){
+ if(substring(my_location().to_string(),0,11) == "Shadow Rift" || my_location() == $location[Thugnderdome])
    if(equipped_item($slot[Shirt]) != $item[Jurassic Parka]){
      abort("Went to YR without a parka on!");
    }

--- a/scripts/ezhobo_combat.ash
+++ b/scripts/ezhobo_combat.ash
@@ -28,7 +28,7 @@ string hobo_combat(int round, monster mon_encountered, string pagetext) {
 
 
  // Check for non-hobo zones. (e.g YRs from parka)
- if(substring(my_location().to_string(),0,11) == "Shadow Rift" || my_location() == $location[Thugnderdome])
+ if(substring(my_location().to_string(),0,11) == "Shadow Rift" || my_location() == $location[Thugnderdome]){
    if(equipped_item($slot[Shirt]) != $item[Jurassic Parka]){
      abort("Went to YR without a parka on!");
    }


### PR DESCRIPTION
I was running into a problem with ShadowRealm location matching when using this with some clannies. It wasn't firing the yellow ray and instead was using Lunging Thrust Smack.

I tweaked the detection logic in the ezhobo_combat.ash to stop matching against the $location() object and instead do basic string matching.

My clannies and I tested it out over this past weekend and the issue did not re-appear.

Thanks for such a helpful script! I hope this can make it even smoother for folks!